### PR TITLE
Draggable addition

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "rangy": "^1.3.0",
     "react": "0.14.7",
     "react-dom": "^0.14.7",
+    "react-draggable": "^2.0.0-beta3",
     "react-native-listener": "^1.0.1",
     "react-spinner": "^0.2.3",
     "react-webcam": "0.0.10",

--- a/src/content/components/Container.jsx
+++ b/src/content/components/Container.jsx
@@ -3,6 +3,7 @@ import React from 'react'
 import ReactDOM from 'react-dom'
 import classnames from 'classnames'
 import NativeListener from 'react-native-listener'
+import Draggable from 'react-draggable'
 
 import * as Extension from 'content/lib/extension'
 import styles from './Container.scss'
@@ -69,6 +70,7 @@ class Container extends React.Component {
     let classes = classnames(styles.container, this.props.className)
 
     return (
+      <Draggable>
       <div className={styles.wrapper} style={style} >
         <Close onClick={this.unmount}/>
         <div className={classes}>
@@ -77,6 +79,7 @@ class Container extends React.Component {
           <Version />
         </div>
       </div>
+      </Draggable>
     )
   }
 }

--- a/src/content/components/Container.jsx
+++ b/src/content/components/Container.jsx
@@ -71,14 +71,14 @@ class Container extends React.Component {
 
     return (
       <Draggable>
-      <div className={styles.wrapper} style={style} >
-        <Close onClick={this.unmount}/>
-        <div className={classes}>
-          { this.props.children }
-          <Icon />
-          <Version />
+        <div className={styles.wrapper} style={style} >
+          <Close onClick={this.unmount}/>
+          <div className={classes}>
+            { this.props.children }
+            <Icon />
+            <Version />
+          </div>
         </div>
-      </div>
       </Draggable>
     )
   }


### PR DESCRIPTION
I had an issue with a text box at the bottom of the slack web app and the 'command box' appending below so I couldn't use it.  Because there was already an issue open requesting the 'command box' to appear above the text box I felt like giving the user the ability drag the 'command box'  to the most convenient sport on the page seems like the best solution.  
I am not sure if there should be some indicator to the user that the box is draggable or if it should be implied. I think can be discussed but the functionality is a big overall enhancement.
I also wonder if this version of 'react-draggable' is the most stable for prod.. very new to contributing. I appreciate any feedback!
